### PR TITLE
feat: 시간표 강의 추가 기능 보완 1차

### DIFF
--- a/src/components/createpage/TimeTable.jsx
+++ b/src/components/createpage/TimeTable.jsx
@@ -3,6 +3,7 @@ import { isMobile } from 'react-device-detect';
 import { useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import ReactDOM from 'react-dom';
+import TimeTableClassCell from './TimeTableClassCell';
 
 // props로 초기화 버튼 null 처리하기
 const TimeTable = () => {
@@ -16,8 +17,6 @@ const TimeTable = () => {
         const hour = Math.floor(index * timeInterval) + startHour;
         return index % 2 === 0 ? hour : hour + 0.5;
     });
-
-    // console.log(timeSlots);
 
     const dayMappings = {
         월: 'Mon',
@@ -40,55 +39,7 @@ const TimeTable = () => {
         cellRefs.current[`${day}-${timeSlot}`] = ref;
     };
 
-    const AdditionalContent = ({ selectedData }) => (
-        <BlockText>
-            <div>{selectedData[0].name}</div>
-            <br />
-            <div>{selectedData[0].place}</div>
-        </BlockText>
-    );
-
-    const showClassBlock = selectedData => {
-        console.log('showClassBlock');
-        console.log(selectedData[0].startTime);
-        // 시작시간 시랑 분 분리
-        const [startH, startM] = selectedData[0].startTime
-            .split(':')
-            .map(str => parseInt(str, 10));
-
-        // id 변수
-        const findId = `${dayMappings[selectedData[0].day]}-${startH}`;
-
-        console.log(startH);
-        console.log(findId);
-
-        // 원하는 key를 가진 요소에 접근
-        const targetElement = cellRefs.current[findId];
-
-        // targetElement가 정상적으로 찾아졌을 때
-        if (targetElement) {
-            // class 추가
-            targetElement.classList.add('selected');
-
-            // rowSpan 속성 추가
-            targetElement.rowSpan = '3';
-
-            // AdditionalContent 컴포넌트를 생성하여 targetElement의 하위로 추가
-            ReactDOM.render(
-                <AdditionalContent selectedData={selectedData} />,
-                targetElement,
-            );
-        }
-    };
-
-    useEffect(() => {
-        console.log('시작');
-        if (selectedData && selectedData.length > 0) {
-            console.log(selectedData);
-            console.log('timetable 값 들어옴');
-            showClassBlock(selectedData);
-        }
-    }, [selectedData]);
+    const etcDescDivRef = useRef(null);
 
     return (
         <TimeTableContainer>
@@ -120,7 +71,15 @@ const TimeTable = () => {
                                     isfirst={index === 0}
                                     islast={index === numberOfSlots - 1}
                                     ref={ref => setCellRef(day, timeSlot, ref)}
-                                ></TableCell>
+                                >
+                                    {/* 각 시간 슬롯에 해당하는 선택된 데이터를 표시합니다. */}
+                                    <TimeTableClassCell
+                                        selectedData={selectedData}
+                                        dayMappings={dayMappings}
+                                        cellRefs={cellRefs}
+                                        etcDescDivRef={etcDescDivRef}
+                                    />
+                                </TableCell>
                             ))}
                         </tr>
                     ))}
@@ -128,7 +87,7 @@ const TimeTable = () => {
             </table>
             <EtcDiv>
                 <TableText>etc</TableText>
-                <EtcDescDiv></EtcDescDiv>
+                <EtcDescDiv ref={etcDescDivRef}></EtcDescDiv>
             </EtcDiv>
         </TimeTableContainer>
     );
@@ -200,7 +159,7 @@ const TableCell = styled.td`
             : 'none'};
 
     &.selected {
-        background-color: #5f96ff;
+        /* background-color: #5f96ff; */
         color: white;
         border-radius: 9px;
         font-size: 10px;
@@ -245,6 +204,10 @@ const EtcDescDiv = styled.div`
     border-radius: 8px;
     margin-top: 2px;
     margin-left: auto;
+
+    font-size: 10px;
+    font-weight: 500;
+    padding: 1%;
 
     ${isMobile &&
     `

--- a/src/components/createpage/TimeTableClassCell.jsx
+++ b/src/components/createpage/TimeTableClassCell.jsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef } from 'react';
+import styled from 'styled-components';
+import ReactDOM from 'react-dom';
+import { CLASS_BLOCK_COLOR } from '../../consts/timeTableInput';
+
+const TimeTableClassCell = ({
+    selectedData,
+    dayMappings,
+    cellRefs,
+    etcDescDivRef,
+}) => {
+    // 배경색 칠한 td 위에 올려둘 강의명과 강의장소
+    const AdditionalContent = ({ selectedData }) => (
+        <BlockText>
+            <div>{selectedData.name}</div>
+            <br />
+            <div>{selectedData.place}</div>
+        </BlockText>
+    );
+
+    // 강의 블록 길이 계산하는 함수
+    const calculateBlockLength = (startH, endH) => {
+        const classTime = endH - startH;
+        if (classTime === 3) {
+            return 6;
+        } else if (classTime >= 4 && classTime <= 5) {
+            return 9;
+        } else if (classTime === 6) {
+            return 12;
+        } else if (classTime >= 7 && classTime <= 8) {
+            return 15;
+        } else if (classTime === 9) {
+            return 18;
+        } else if (classTime >= 10 && classTime <= 11) {
+            return 21;
+        } else {
+            return 3;
+        }
+    };
+
+    // 강의 블록 올리는 로직
+    const showClassBlock = selectedData => {
+        selectedData.forEach((data, index) => {
+            console.log('showClassBlock-----------');
+
+            // 지정된 시간이 없는 경우
+            if (data.startTime === -1) {
+                etcDescDivRef.current.innerText = `${data.name} `;
+                return;
+            } else {
+                // 강의 시간이 하나인 경우
+
+                // 강의 시간이 2개인 경우 -> 배경색 달라지는 문제 해결해야 함
+
+                // 시작시간 시랑 분 분리
+                const [startH, startM] = data.startTime
+                    .split(':')
+                    .map(str => parseInt(str, 10));
+
+                // 끝시간 시랑 분 분리
+                const [endH, endM] = data.endTime
+                    .split(':')
+                    .map(str => parseInt(str, 10));
+
+                // id 변수
+                const findId = `${dayMappings[data.day]}-${startH}`;
+
+                // 원하는 key를 가진 요소에 접근
+                const targetElement = cellRefs.current[findId];
+
+                // targetElement가 정상적으로 찾아졌을 때
+                if (targetElement) {
+                    // class 추가
+                    targetElement.classList.add('selected');
+                    targetElement.style.backgroundColor =
+                        CLASS_BLOCK_COLOR[index];
+
+                    // rowSpan 속성 추가
+                    targetElement.rowSpan = calculateBlockLength(startH, endH);
+
+                    // AdditionalContent 컴포넌트를 생성하여 targetElement의 하위로 추가
+                    ReactDOM.render(
+                        <AdditionalContent selectedData={data} />,
+                        targetElement,
+                    );
+                }
+            }
+        });
+    };
+
+    useEffect(() => {
+        console.log('시작');
+        if (selectedData && selectedData.length > 0) {
+            console.log(selectedData);
+            console.log('timetable 값 들어옴');
+            showClassBlock(selectedData);
+        }
+    }, [selectedData]);
+
+    return null;
+};
+
+export default TimeTableClassCell;
+
+const BlockText = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;

--- a/src/components/createpage/TimeTableInput.jsx
+++ b/src/components/createpage/TimeTableInput.jsx
@@ -58,18 +58,54 @@ const TimeTableInput = () => {
         // 객체 형태로 가공하여 새로운 데이터 생성
         // 만약 추가했을 경우 객체 2개를 보내기
 
-        const newData = {
-            day: selectedDateTime.day,
-            startTime: selectedDateTime.startTime,
-            endTime: selectedDateTime.endTime,
-            place: selectedPlace,
-            name: selectedClassName,
-        };
+        let newData1, newData2;
 
-        console.log(newData);
+        if (isChecked) {
+            // 지정된 시간 없음인 경우
+            newData1 = {
+                day: selectedDateTime.day,
+                startTime: -1,
+                endTime: -1,
+                place: selectedPlace,
+                name: selectedClassName,
+            };
 
-        // 액션을 디스패치하여 Redux Store의 selectedData 배열에 추가
-        dispatch(addSelectedData(newData));
+            // 액션을 디스패치하여 Redux Store의 selectedData 배열에 추가
+            dispatch(addSelectedData(newData1));
+        } else if (isAddBtnPressed) {
+            // 강의 시간이 2개인 경우
+            newData1 = {
+                day: selectedDateTime.day,
+                startTime: selectedDateTime.startTime,
+                endTime: selectedDateTime.endTime,
+                place: selectedPlace,
+                name: selectedClassName,
+            };
+
+            newData2 = {
+                day: plusSelectedDateTime.day,
+                startTime: plusSelectedDateTime.startTime,
+                endTime: plusSelectedDateTime.endTime,
+                place: selectedPlace,
+                name: selectedClassName,
+            };
+
+            dispatch(addSelectedData(newData1));
+            dispatch(addSelectedData(newData2));
+        } else {
+            // 일반적인 경우 (강의 시간 1개)
+            newData1 = {
+                day: selectedDateTime.day,
+                startTime: selectedDateTime.startTime,
+                endTime: selectedDateTime.endTime,
+                place: selectedPlace,
+                name: selectedClassName,
+            };
+
+            dispatch(addSelectedData(newData1));
+        }
+
+        // 입력창 초기화
     };
 
     return (
@@ -100,7 +136,7 @@ const TimeTableInput = () => {
                 </S.InputDiv>
 
                 {isAddBtnPressed === true ? (
-                    <div style={{width: "72%"}}>
+                    <div style={{ width: '72%' }}>
                         <DateTimeDropdown
                             isOpen={isSecondOpen}
                             setIsOpen={setIsSecondOpen}
@@ -109,9 +145,13 @@ const TimeTableInput = () => {
                             isChecked={isChecked}
                             order='second'
                         />
-                        <S.MinusBtn src={subtract_course} alt="-버튼" onClick={() => {
+                        <S.MinusBtn
+                            src={subtract_course}
+                            alt='-버튼'
+                            onClick={() => {
                                 setIsAddBtnPressed(false);
-                            }}/>
+                            }}
+                        />
                     </div>
                 ) : (
                     <S.ButtonDiv>

--- a/src/consts/timeTableInput.js
+++ b/src/consts/timeTableInput.js
@@ -48,3 +48,15 @@ export const PickerOptions = {
     allowTouchMove: true,
     nested: true,
 };
+
+export const CLASS_BLOCK_COLOR = [
+    '#1962ED',
+    '#5F96FF',
+    '#B7C8E9',
+    '#494F5A',
+    '#949AA5',
+    '#646870',
+    '#A5F43F',
+    '#FF7E63',
+    '#84D71A',
+];


### PR DESCRIPTION
## Summary

### 시간표 강의 추가 페이지(createpage)

-   강의 추가 기능을 보완했습니다.
-  지정된 시간 없음, 강의 시간 2개인 경우를 고려하여 강의 블록을 추가할 수 있도록 수정하였습니다.
![image](https://github.com/SamwaMoney/Timetable-Artist-front/assets/81233784/5914e8da-ab77-4dab-8ac9-3f02e358b2d4)


## To Reviewers

-   현재 강의 블록이 오른쪽으로 밀리는 문제가 일부 발생하고 있습니다.
-  지금 코드 방식을 보면, td에 시간 슬롯을 기준으로 key와 id를 부여하고 있고, 시작 시간 td를 찾아서 rowSpan을 주는 방식으로 강의블록을 표시하고 있는 상황입니다.
- 이렇게 코드를 짜다보니, 예를 들어 Mon-8자리에 rowSpan=3을 주어 월요일 8:00-9:30 강의 블록을 표시할 경우 Mon-8.5부터 Fri-8.5, Mon-9부터 Fri-9라는 id를 가진 td가 오른쪽으로 한칸씩 밀리는 문제가 발생합니다.. 이러한 상황에서 화요일 8:00~9:30을 표시할 경우 수요일 자리에 강의 블록이 생기는 문제가 발생하고 있습니다..
- 강의 블록을 position: absolute를 주든, 아니면 rowSpan 사용을 자제하든, 또는 시간표 블록 생성방식을 바꾸든 해야할 것 같습니다.. 이번주 안으로 수정해볼테니 조금만 기다려주세요!
