### PR TITLE
[Feat] TimeTable 컴포넌트 isScorePage props 추가

### DIFF
--- a/src/components/createpage/CreateTimeTable.jsx
+++ b/src/components/createpage/CreateTimeTable.jsx
@@ -16,7 +16,7 @@ const CreateTimeTable = () => {
                                 *강의 블록을 클릭하면 하나씩 삭제할 수 있어요.
                             </S.NoticeText>
                         </S.ResetDiv>
-                        <TimeTable />
+                        <TimeTable isScorePage='false' />
                     </S.TimeTableDiv>
 
                     <TimeTableInput />

--- a/src/components/createpage/M_CreateTimeTable.jsx
+++ b/src/components/createpage/M_CreateTimeTable.jsx
@@ -24,7 +24,7 @@ const MCreateTimeTable = () => {
                         <S.MNicknameText>{nickname}</S.MNicknameText>의 시간표
                     </S.MTimeTableText>
 
-                    <TimeTable />
+                    <TimeTable isScorePage="false"/>
 
                     <S.MAddButtonDiv>
                         <S.MAddButton

--- a/src/components/createpage/TimeTable.jsx
+++ b/src/components/createpage/TimeTable.jsx
@@ -5,7 +5,7 @@ import { useSelector } from 'react-redux';
 import TimeTableRow from './TimeTableRow';
 
 // props로 초기화 버튼 null 처리하기
-const TimeTable = () => {
+const TimeTable = ({ isScorePage }) => {
     const startHour = 8;
     const endHour = 20;
     const timeInterval = 0.5;
@@ -42,7 +42,9 @@ const TimeTable = () => {
     }, [reduxSelectedData]);
 
     return (
-        <TimeTableContainer>
+        <TimeTableContainer
+            className={isScorePage === "true" ? 'isScorePage' : ''}
+        >
             <table>
                 <thead>
                     <tr>
@@ -82,7 +84,9 @@ const TimeTable = () => {
                         selectedData.map(lecture => {
                             if (lecture.startTime === null) {
                                 return (
-                                    <div key={lecture.className}>{lecture.className}</div>
+                                    <div key={lecture.className}>
+                                        {lecture.className}
+                                    </div>
                                 );
                             }
                             return null;
@@ -114,6 +118,10 @@ const TimeTableContainer = styled.div`
        border: 0px;
        width: 90%;
     `}
+
+    &.isScorePage {
+        pointer-events: none;
+    }
 `;
 
 const DayCell = styled.th`


### PR DESCRIPTION
## Summary

### TimeTable 컴포넌트

-   isScorePage props 추가했습니다.
-  isScorePage props가 "true"일 경우, pointer-events: none이 적용되어 클릭 이벤트가 일어나지 않습니다.
![image](https://github.com/SamwaMoney/Timetable-Artist-front/assets/81233784/16c1f800-0ab8-4cc6-8c83-6a4e8bcbdd8b)


## To Reviewers

-   결과 페이지에서는 redux store에 있는 데이터가 아니라 api로 받아온 데이터를 TimeTable 컴포넌트에 띄워야 할 것 같은데 한비님 시간표 강의 데이터 조회 api 구현해주시고 톡 남겨주시면 제가 TimeTable 컴포넌트 수정하도록 하겠습니다.
