### PR TITLE
[Fix] localStorage 아이템 삭제 방식 수정 및 tableId 가져오는 방식 수정

### DIFF
--- a/src/api/http.js
+++ b/src/api/http.js
@@ -48,10 +48,7 @@ http.interceptors.request.use(
     async error => {
         // ex) refreshToken이 만료된 경우
         console.log('리프레시 에러', error);
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        localStorage.removeItem('memberId');
-        localStorage.removeItem('expireAt');
+        localStorage.clear();
         window.location.reload();
         return Promise.reject(error);
     },

--- a/src/api/members.js
+++ b/src/api/members.js
@@ -30,10 +30,7 @@ export const DeleteMember = async () => {
         const memberId = localStorage.getItem('memberId');
         const res = await http.delete(`/members/${memberId}`);
         console.log(res, '탈퇴 성공');
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        localStorage.removeItem('memberId');
-        localStorage.removeItem('expireAt');
+        localStorage.clear();
         return 'Account deletion successful';
     } catch (err) {
         console.log(err);
@@ -87,12 +84,7 @@ export const Logout = async () => {
             },
         });
         console.log(res, '로그아웃 성공');
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('refreshToken');
-        localStorage.removeItem('memberId');
-        localStorage.removeItem('expireAt');
-        localStorage.removeItem('username');
-        localStorage.removeItem('tableId');
+        localStorage.clear();
         window.location.replace('/ranking');
         return res;
     } catch (err) {

--- a/src/api/timetables.js
+++ b/src/api/timetables.js
@@ -26,6 +26,7 @@ export const CreateTable = async () => {
             memberId: memberId,
         });
         console.log(res);
+        GetTableId();
     } catch (err) {
         console.log('시간표 생성 에러', err);
     }

--- a/src/components/_common/EditModal.jsx
+++ b/src/components/_common/EditModal.jsx
@@ -1,5 +1,5 @@
 import { M } from './Modal.style';
-import { CreateTable, DeleteTable, GetTableId } from '../../api/timetables';
+import { CreateTable, DeleteTable } from '../../api/timetables';
 
 import { useNavigate } from 'react-router-dom';
 import { isMobile } from 'react-device-detect';
@@ -11,7 +11,6 @@ const EditModal = ({ setIsEditModalOpen }) => {
         const tableId = localStorage.getItem('tableId');
         DeleteTable(tableId);
         CreateTable();
-        GetTableId();
         setIsEditModalOpen(false);
         navigate('/create');
     };

--- a/src/components/_common/Hamburger.jsx
+++ b/src/components/_common/Hamburger.jsx
@@ -2,7 +2,7 @@ import { S } from './Hamburger.style';
 import EditModal from './EditModal';
 import WithdrawalModal from './WithdrawalModal';
 import { Logout, isLogin } from '../../api/members';
-import { CreateTable, GetTableId } from '../../api/timetables';
+import { CreateTable } from '../../api/timetables';
 
 import { useState } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
@@ -32,7 +32,6 @@ const Hamburger = () => {
                 setIsEditModalOpen(true);
             } else {
                 CreateTable();
-                GetTableId();
                 navigate('/create');
             }
         } else {


### PR DESCRIPTION
## Summary

### 작업한 페이지명

-   로컬에 로그아웃, 탈퇴, 토큰 리프레시 재발급 실패 시 localStorage.clear() 가 되도록 수정했습니다.
- CreateTable() 호출 후 GetTableId()를 호출했는데 Get이 먼저 실행되어 null이나 이전 id를 반환하는 문제가 있어 CreateTable() 안에 GetTableId()를 호출하는 방식으로 변경했습니다.

## To Reviewers

-   로그아웃 후 다른 계정 로그인 시 새 테이블 아이디 생성이 잘 동작하는지 확인해 주세요.
- 현재 테이블 삭제가 AWS에 반영이 되지 않아 새 시간표 만들기 모달의 "생성" 버튼을 클릭하시면 2개가 생성되어 GetTableId()를 가져올 수 없는 문제가 발생합니다. 참고해 주세요.
