### PR TITLE
[Feat] 점수 페이지에서 redux에 점수 저장 추가

### DIFF
--- a/src/components/scorepage/M_Score.jsx
+++ b/src/components/scorepage/M_Score.jsx
@@ -2,6 +2,7 @@ import { S } from './M_Score.style';
 import { useState, useEffect } from 'react';
 import { useScript } from './useScript';
 import { useNavigate } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import html2canvas from 'html2canvas';
 import { TwitterShareButton } from 'react-share';
 import { RWebShare } from 'react-web-share';
@@ -38,6 +39,7 @@ import type11 from '../../assets/scorepage/typeImg/type11.png';
 import type12 from '../../assets/scorepage/typeImg/type12.png';
 import type13 from '../../assets/scorepage/typeImg/type13.png';
 import type14 from '../../assets/scorepage/typeImg/type14.png';
+import { addMyScore } from '../../reducer/action';
 
 const M_Score = () => {
     const [isLoading, setIsLoading] = useState(true);
@@ -52,6 +54,7 @@ const M_Score = () => {
     const mainURL = window.location.href.slice(0, -5);
     const status = useScript('https://developers.kakao.com/sdk/js/kakao.js');
     const navigate = useNavigate();
+    const dispatch = useDispatch();
     const memberId = localStorage.getItem('memberId');
     const typeImage = [
         type1,
@@ -173,7 +176,7 @@ const M_Score = () => {
             setData(res.data);
             setIsLoading(false);
             setIsUploaded(res.data.ranking);
-            console.log(isUploaded);
+            dispatch(addMyScore(res.data.score));
         }
     };
 

--- a/src/components/scorepage/Score.jsx
+++ b/src/components/scorepage/Score.jsx
@@ -1,6 +1,7 @@
 import { S } from './Score.style';
 import { useState, useEffect } from 'react';
 import { useScript } from './useScript';
+import { useDispatch } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import html2canvas from 'html2canvas';
 import { TwitterShareButton } from 'react-share';
@@ -37,6 +38,7 @@ import type11 from '../../assets/scorepage/typeImg/type11.png';
 import type12 from '../../assets/scorepage/typeImg/type12.png';
 import type13 from '../../assets/scorepage/typeImg/type13.png';
 import type14 from '../../assets/scorepage/typeImg/type14.png';
+import { addMyScore } from '../../reducer/action';
 
 const Score = () => {
     const [isLoading, setIsLoading] = useState(true);
@@ -53,6 +55,7 @@ const Score = () => {
     const mainURL = window.location.href.slice(0, -5);
     const status = useScript('https://developers.kakao.com/sdk/js/kakao.js');
     const navigate = useNavigate();
+    const dispatch = useDispatch();
     const memberId = localStorage.getItem('memberId');
     const typeImage = [
         type1,
@@ -176,6 +179,8 @@ const Score = () => {
             setData(res.data);
             setIsLoading(false);
             setIsUploaded(res.data.ranking);
+            dispatch(addMyScore(res.data.score));
+            console.log(res.data.score);
         }
     };
 

--- a/src/reducer/myInfo.js
+++ b/src/reducer/myInfo.js
@@ -24,7 +24,7 @@ const myInfoReducer = (state = initialState, action) => {
             const score_state = { ...state };
             return {
                 ...score_state,
-                myUserName: action.payload,
+                myScore: action.payload,
             };
 
         default:


### PR DESCRIPTION
## Summary

### 시간표 점수 페이지

- 점수 페이지에서 시간표 정보 조회하면서 score redux에 저장 추가 

## To Reviewers

-   전달하고 싶은 내용 (만약 재사용 가능한 컴포넌트 있다면 설명)
