### PR TITLE
[Fix] createpage dropdown open일 때 맨 윗칸 클릭 시 close하도록 수정

### DIFF
--- a/src/components/createpage/DateTimeDropdown.jsx
+++ b/src/components/createpage/DateTimeDropdown.jsx
@@ -59,7 +59,7 @@ const DateTimeDropdown = ({
                             alignItems: 'center',
                             justifyContent: 'space-between',
                         }}
-                        onClick={() => changeOpen(0, true)}
+                        onClick={() => changeOpen(0, !isOpen[0])}
                     >
                         <S.DescDayText>
                             {selectedDateTime.weekday}
@@ -93,7 +93,7 @@ const DateTimeDropdown = ({
                             alignItems: 'center',
                             justifyContent: 'space-between',
                         }}
-                        onClick={() => changeOpen(1, true)}
+                        onClick={() => changeOpen(1, !isOpen[1])}
                     >
                         <S.DescTimeText>
                             {selectedDateTime.startTime}
@@ -127,7 +127,7 @@ const DateTimeDropdown = ({
                             alignItems: 'center',
                             justifyContent: 'space-between',
                         }}
-                        onClick={() => changeOpen(2, true)}
+                        onClick={() => changeOpen(2, !isOpen[2])}
                     >
                         <S.DescTimeText>
                             {selectedDateTime.endTime}

--- a/src/components/createpage/PlaceDropdown.jsx
+++ b/src/components/createpage/PlaceDropdown.jsx
@@ -24,7 +24,7 @@ const PlaceDropdown = ({
                             alignItems: 'center',
                             justifyContent: 'space-between',
                         }}
-                        onClick={() => setIsPlaceOpen(true)}
+                        onClick={() => setIsPlaceOpen(!isPlaceOpen)}
                     >
                         <S.DescPlaceText>{selectedPlace}</S.DescPlaceText>
                         <S.DownIcon


### PR DESCRIPTION
## Summary

### createpage
![image](https://github.com/SamwaMoney/Timetable-Artist-front/assets/81233784/26f20d88-92d4-471d-9388-574edd3d0654)
-  드롭다운에서 맨 윗 칸 클릭 시 close되도록 수정했습니다.

## To Reviewers

-   혹시 지금 localhost:3000에서 api가 작동이 안되고 있는게 맞나요? scorepage에 시간표 오류를 수정하고 싶은데 확인이 안되네요..
