### PR TITLE
fix: scorepage 시간표 온라인 강의 표시, 시간표 폰트 크기 조정

### DIFF
--- a/src/components/createpage/TimeTable.jsx
+++ b/src/components/createpage/TimeTable.jsx
@@ -3,7 +3,6 @@ import { isMobile } from 'react-device-detect';
 import { useState, useEffect, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import TimeTableRow from './TimeTableRow';
-import { CLASS_BLOCK_COLOR } from '../../consts/timeTableInput';
 
 // props로 초기화 버튼 null 처리하기
 const TimeTable = ({ isScorePage, isHidden, classList }) => {
@@ -48,23 +47,26 @@ const TimeTable = ({ isScorePage, isHidden, classList }) => {
 
     // 점수 페이지 용 데이터 가공
     const scorePageClassData = classList
-        ? classList.map((classData, index) => {
+        ? classList.map(classData => {
               // 새로운 객체를 생성하여 원본 객체의 프로퍼티를 복사
               const newClassData = { ...classData };
 
-              // 요일 한글로 바꿔주기
-              newClassData.weekday = getKeyByValue(
-                  dayMappings,
-                  newClassData.weekday,
-              );
+              // 요일 한글로 바꿔주기 (ONLINE 수업일 경우 제외)
+              if (newClassData.weekday !== 'ONLINE') {
+                  newClassData.weekday = getKeyByValue(
+                      dayMappings,
+                      newClassData.weekday,
+                  );
+              }
 
               // startTime, endTime 추가
-              newClassData.startTime = `${newClassData.startH}:${newClassData.startM}`;
-              newClassData.endTime = `${newClassData.endH}:${newClassData.endM}`;
-
-              // 배경색 추가
-              //   newClassData.bgColor =
-              //       CLASS_BLOCK_COLOR[index >= 8 ? index - 8 : index];
+              if (newClassData.startH === null) {
+                  newClassData.startTime = null;
+                  newClassData.endTime = null;
+              } else {
+                  newClassData.startTime = `${newClassData.startH}:${newClassData.startM}`;
+                  newClassData.endTime = `${newClassData.endH}:${newClassData.endM}`;
+              }
 
               return newClassData;
           })
@@ -111,28 +113,49 @@ const TimeTable = ({ isScorePage, isHidden, classList }) => {
                     ))}
                 </tbody>
             </table>
+
             <EtcDiv>
                 <TableText>etc</TableText>
                 <EtcDescDiv ref={etcDescDivRef}>
-                    {selectedData &&
-                        selectedData.map(lecture => {
-                            if (lecture.startTime === null) {
-                                return (
-                                    <div
-                                        key={lecture.className}
-                                        style={{
-                                            display:
-                                                isHidden === true
-                                                    ? 'none'
-                                                    : 'block',
-                                        }}
-                                    >
-                                        {lecture.className}
-                                    </div>
-                                );
-                            }
-                            return null;
-                        })}
+                    {isScorePage === true
+                        ? scorePageClassData &&
+                          scorePageClassData.map(lecture => {
+                              if (lecture.weekday === 'ONLINE') {
+                                  return (
+                                      <div
+                                          key={lecture.className}
+                                          style={{
+                                              display:
+                                                  isHidden === true
+                                                      ? 'none'
+                                                      : 'block',
+                                          }}
+                                      >
+                                          {lecture.className}
+                                      </div>
+                                  );
+                              }
+                              return null;
+                          })
+                        : selectedData &&
+                          selectedData.map(lecture => {
+                              if (lecture.startTime === null) {
+                                  return (
+                                      <div
+                                          key={lecture.className}
+                                          style={{
+                                              display:
+                                                  isHidden === true
+                                                      ? 'none'
+                                                      : 'block',
+                                          }}
+                                      >
+                                          {lecture.className}
+                                      </div>
+                                  );
+                              }
+                              return null;
+                          })}
                 </EtcDescDiv>
             </EtcDiv>
         </TimeTableContainer>

--- a/src/components/createpage/TimeTableCell.jsx
+++ b/src/components/createpage/TimeTableCell.jsx
@@ -126,11 +126,12 @@ const TableCell = styled.td`
             : 'none'};
 
     &.selected {
-        /* background-color: #5f96ff; */
         color: white;
         border-radius: 9px;
-        font-size: 10px;
+        font-size: 0.5vw;
         position: relative;
+
+        ${isMobile && `font-size: 10px;`}
     }
 
     ${isMobile &&
@@ -157,7 +158,7 @@ const BlockText = styled.div`
 
 const BlockNameText = styled.div`
     font-weight: 700;
-    margin-bottom: 10%;
+    margin-bottom: 9%;
 
     &.isHidden {
         display: none;


### PR DESCRIPTION
## Summary

### 작업한 페이지명

-   점수(결과)페이지 시간표에 온라인강의명이 뜨도록 코드를 수정하였습니다. (강의명 숨김 처리 시 온라인 강의명은 사라집니다)
![image](https://github.com/SamwaMoney/Timetable-Artist-front/assets/81233784/51cce1bb-0f95-4aac-a7ef-d38aafa73f53)
![image](https://github.com/SamwaMoney/Timetable-Artist-front/assets/81233784/68594025-498a-4ab4-9dc4-09070105e7c1)

- 시간표 블록 폰트 vw단위로 변경하였습니다 (모바일은 vw로 했을 때 글씨가 매우 작아져서 그냥 px로 고정했습니다)

## To Reviewers

-   앞서 PR에서 언급한 api 연결 문제는 해결되었습니다 (제가 env 파일이 없어서 생긴 문제였습니다)
