### PR TITLE
[Refactor] 랭킹보드 렌더링 개선

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,8 +8,6 @@ import ScorePage from './pages/ScorePage';
 import RankingPage from './pages/RankingPage';
 import AboutUsPage from './pages/AboutUsPage';
 import MenuPage from './pages/M_MenuPage';
-import MError from './components/_common/M_Error';
-import Error from './components/_common/Error';
 import ErrorPage from './pages/ErrorPage';
 import MRankDetail from './components/rankingpage/M_RankDetail';
 import { Provider } from 'react-redux';

--- a/src/components/rankingpage/M_RankDetail.jsx
+++ b/src/components/rankingpage/M_RankDetail.jsx
@@ -12,8 +12,6 @@ import { useEffect, useState } from 'react';
 import RankingApis from '../../api/ranking';
 import { useParams } from 'react-router-dom';
 
-//해당 유저의 아이디를 params로 가져오고, rank의 경우는 쿼리스트링으로 가져옴
-//시간표 채점 결과 조회 api를 사용함.
 const MRankDetail = () => {
     const [searchParams, setSearchParams] = useSearchParams();
     //유저의 랭크
@@ -29,9 +27,8 @@ const MRankDetail = () => {
     const [loading, setLoading] = useState(true);
     const [commentNum, setCommentNum] = useState();
 
+    //디테일 정보 불러오는 로직
     useEffect(() => {
-        //timetableId로 해당 유저의 정보 검색
-        //comment는 따로 검색
         setLoading(true);
         const fetch = async () => {
             const res = await getDetailData(timetableId, memberId);

--- a/src/components/rankingpage/Rank.jsx
+++ b/src/components/rankingpage/Rank.jsx
@@ -18,6 +18,7 @@ const Rank = ({ isLogin }) => {
     //api로 받아온 데이터 관리하는 곳
     const [rankingData, setRankingData] = useState();
     const [currentUserId, setCurrentUserId] = useState();
+    // const [currentUserRank, setCurrentUserRank] = useState();
     const memberId = localStorage.getItem('memberId') || -1;
     const [loading, setLoading] = useState(true);
     const [rankLoading, setRankLoading] = useState(true);
@@ -34,6 +35,7 @@ const Rank = ({ isLogin }) => {
             console.log('받아온 랭킹정보', sort, res);
             setRankingData(res?.data);
             setCurrentUserId(res?.data[0]?.timetableId);
+            // setCurrentUserRank(0);
         };
         fetchData(sort);
     }, [sort]);
@@ -113,6 +115,7 @@ const Rank = ({ isLogin }) => {
                         timetableId={timetableId}
                         getDetailData={getDetailData}
                         setRankingData={setRankingData}
+                        rankingData={rankingData}
                     />
                 </S.Container>
             )}

--- a/src/components/rankingpage/RankDetail.jsx
+++ b/src/components/rankingpage/RankDetail.jsx
@@ -6,40 +6,31 @@ import CmtTag from './rightSection/CmtTag';
 import RightSectionSkeleton from '../../skeleton/RightSectionSkeleton';
 import { useState, useEffect } from 'react';
 import AltTableImg from '../../assets/_common/altTable.png';
-import { useLocation } from 'react-router-dom';
+
 const RankDetail = ({
     memberId,
     currentUserId,
     getRankingList,
-    setLoading,
     setRankingData,
     loading,
     rankLoading,
     getDetailData,
+    rankingData,
 }) => {
     const [currentUser, setCurrentUser] = useState();
     const [commentNum, setCommentNum] = useState();
-    const location = useLocation();
-    const params = new URLSearchParams(location.search);
-    const sort = params.get('sort');
 
     useEffect(() => {
         setCommentNum();
         setCurrentUser();
-        const fetchDetailData = async timetableId => {
-            const res = await getDetailData(timetableId, memberId);
-            setCurrentUser(res?.data);
-        };
-        fetchDetailData(currentUserId);
-        setLoading(false);
-    }, [currentUserId]);
+        const res = rankingData?.filter(
+            data => data.timetableId === currentUserId,
+        );
+        console.log('현재 user정보', res && res[0]);
+        res && setCurrentUser(res[0]);
+    }, [currentUserId, rankingData]);
 
-    // useEffect(() => {
-    //     console.log(loading);
-    //     console.log(rankLoading);
-    // }, [loading, rankLoading]);
-
-    return loading || rankLoading ? (
+    return loading || rankLoading || !currentUser ? (
         <RightSectionSkeleton />
     ) : (
         <S.SmallContainer>

--- a/src/components/rankingpage/Ranking.style.js
+++ b/src/components/rankingpage/Ranking.style.js
@@ -504,6 +504,19 @@ M.IconButton = styled(IconButton)`
     }
 `;
 
+M.HeartButton = styled(IconButton)`
+    color: black;
+    border-radius: 2vw;
+    margin-right: 1vw;
+    width: 16vw;
+    height: 8vw;
+    position: absolute;
+    left: -8vw;
+    p {
+        font-size: 4vw;
+    }
+`;
+
 S.EventIcon = styled.img`
     width: ${props => (props.width ? props.width : '2vw')}rem;
     cursor: pointer;

--- a/src/components/rankingpage/leftSection/MyScore.jsx
+++ b/src/components/rankingpage/leftSection/MyScore.jsx
@@ -3,10 +3,6 @@ import { useSearchParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
-//로그인 + 시간표 채점 정보가 있을때 생김
-//점수 랭킹 조회 => 내 id와 일치하는 객체의 ranking을 가져와서 보여주기
-
-//랭킹 없음을 보여주는 경우는 없다
 const MyScore = ({ isMobile, datas }) => {
     const [searchParams, setSearchParams] = useSearchParams();
     const sort = searchParams.get('sort') || 'LOWEST';

--- a/src/components/rankingpage/leftSection/OneRanking.jsx
+++ b/src/components/rankingpage/leftSection/OneRanking.jsx
@@ -3,10 +3,8 @@ import { useSearchParams, useNavigate } from 'react-router-dom';
 import { S, M } from '../Ranking.style';
 import CmtTag from '../rightSection/CmtTag';
 import LikeTag from '../rightSection/LikeTag';
-// import AltTableImg from '../../assets/_common/altTable.png';
 import AltTableImg from '../../../assets/_common/altTable.png';
-//선택된 user의 id와 일치하면 해당 유저의 랭킹 색을 초록색으로 바꿔줘야 함
-//받아온 data의 첫번쨰 유저가 default => 클릭할떄마다 바뀜
+
 const OneRanking = ({
     data,
     isMobile,

--- a/src/components/rankingpage/leftSection/RankingList.jsx
+++ b/src/components/rankingpage/leftSection/RankingList.jsx
@@ -13,7 +13,6 @@ const RankingList = ({
 }) => {
     const [searchParams, setSearchParams] = useSearchParams();
     const sort = searchParams.get('sort') || 'LOWEST';
-    //선택한 정렬방식대로 순위 바꿔줌
 
     return (
         <>

--- a/src/components/rankingpage/leftSection/Tab.jsx
+++ b/src/components/rankingpage/leftSection/Tab.jsx
@@ -10,23 +10,6 @@ const TabContainer = ({ isMobile }) => {
     const sort = params.get('sort');
     const [searchParams, setSearchParams] = useSearchParams();
 
-    /*정렬 기준대로 쿼리스트링을 바꿔줌*/
-    // const onMoveSortPage = e => {
-    //     const { innerText } = e.target;
-    //     console.log(innerText);
-    //     if (innerText === '최악의 시간표') {
-    //         searchParams.set('sort', 'LOWEST');
-    //         searchParams.set('rank', 1);
-    //     } else if (innerText === '최고의 시간표') {
-    //         searchParams.set('sort', 'HIGHEST');
-    //         searchParams.set('rank', 1);
-    //     } else {
-    //         searchParams.set('sort', 'LIKE');
-    //         searchParams.set('rank', 1);
-    //     }
-    //     setSearchParams(searchParams);
-    // };
-
     const onMoveSortPage = sortValue => {
         console.log(sortValue);
         if (sortValue === 'HIGHEST') {

--- a/src/components/rankingpage/rightSection/CmtLikeBtn.jsx
+++ b/src/components/rankingpage/rightSection/CmtLikeBtn.jsx
@@ -18,8 +18,8 @@ const CmtLikeBtn = ({
     const memberId = localStorage.getItem('memberId') || -1;
     const params = useParams();
     const tableId = params.id;
-    console.log('timetime', timetableId);
-    //좋아요 누르기
+
+    //댓글 좋아요 누르기
     const onGiveLike = async () => {
         if (memberId === -1) {
             return alert('로그인이 필요한 기능입니다.');
@@ -28,10 +28,13 @@ const CmtLikeBtn = ({
         setLikeCount(prev => prev + 1);
         const res = await RankingApis.PostCommentLike(replyId, memberId);
         //서버 요청 실패시 롤백
-        if (res?.status !== 201) {
+        if (res?.status >= 300) {
             setIsLike(false);
             setLikeCount(prev => prev - 1);
+        } else {
+            setIsLike(true);
         }
+        //댓글 다시 불러오기
         if (isMobile) {
             getCommentData(tableId, memberId);
         } else {
@@ -39,7 +42,7 @@ const CmtLikeBtn = ({
         }
     };
 
-    //좋아요 취소
+    //댓글 좋아요 취소
     const onCancelLike = async () => {
         setIsLike(false);
         setLikeCount(prev => {
@@ -48,12 +51,20 @@ const CmtLikeBtn = ({
             }
             return prev - 1;
         });
-        //좋아요 취소하는 api 로직
-        await RankingApis.DeleteCommentLike(replyId, memberId);
-        if (isMobile) {
-            await getCommentData(tableId, memberId);
+        //댓글 좋아요 취소 로직
+        const res = await RankingApis.DeleteCommentLike(replyId, memberId);
+        //서버 요청 실패시 롤백
+        if (res?.status >= 300) {
+            setIsLike(true);
+            setLikeCount(prev => prev - 1);
         } else {
-            await getCommentData(timetableId, memberId);
+            setIsLike(false);
+        }
+        //댓글 다시 불러오기
+        if (isMobile) {
+            getCommentData(tableId, memberId);
+        } else {
+            getCommentData(timetableId, memberId);
         }
     };
 

--- a/src/components/rankingpage/rightSection/CmtTag.jsx
+++ b/src/components/rankingpage/rightSection/CmtTag.jsx
@@ -1,19 +1,19 @@
 import { S, M } from '../Ranking.style';
 import Comment from '../../../assets/rankingpage/comment.png';
 const CmtTag = ({ isMobile, number }) => {
-    return isMobile
-        ? number >= 0 && (
-              <M.IconButton>
-                  <S.NoEventIcon width={2} src={Comment} alt='댓글' />
-                  <p>{number}</p>
-              </M.IconButton>
-          )
-        : number >= 0 && (
-              <S.IconButton>
-                  <S.NoEventIcon width={2} src={Comment} alt='댓글' />
-                  <p>{number}</p>
-              </S.IconButton>
-          );
+    return isMobile ? (
+        <M.IconButton>
+            <S.NoEventIcon width={2} src={Comment} alt='댓글' />
+            <p>{number}</p>
+        </M.IconButton>
+    ) : (
+        number >= 0 && (
+            <S.IconButton>
+                <S.NoEventIcon width={2} src={Comment} alt='댓글' />
+                <p>{number}</p>
+            </S.IconButton>
+        )
+    );
 };
 
 export default CmtTag;

--- a/src/components/rankingpage/rightSection/LikeBtn.jsx
+++ b/src/components/rankingpage/rightSection/LikeBtn.jsx
@@ -37,14 +37,18 @@ const LikeBtn = ({
         const res = await RankingApis.PostTimeTableLike(timetableId, memberId);
         console.log('좋아요 기능', res);
         //서버 요청 실패시 롤백
-        if (res?.status !== 201) {
+        if (res?.status >= 300) {
             setIsLike(false);
-            setLikeNum(prev => prev - 1);
+            setLikeNum(prev => {
+                if (prev === 0) {
+                    return prev;
+                }
+                return prev - 1;
+            });
         } else {
             setIsLike(true);
         }
         if (sort === 'LIKE') {
-            console.log('좋아요 재정렬', sort, memberId);
             const res = await getRankingList(sort, memberId);
             setRankingData(res?.data);
         }
@@ -58,9 +62,8 @@ const LikeBtn = ({
             timetableId,
             memberId,
         );
-        console.log('좋아요 취소 결과', res?.status);
         //서버 요청 실패시 롤백
-        if (res?.status !== 200) {
+        if (res?.status >= 300) {
             setIsLike(true);
             setLikeNum(prev => prev + 1);
         } else {

--- a/src/components/rankingpage/rightSection/OneComment.jsx
+++ b/src/components/rankingpage/rightSection/OneComment.jsx
@@ -2,10 +2,7 @@ import { S, M } from '../Ranking.style';
 import { TiDelete } from 'react-icons/ti';
 import CmtLikeBtn from './CmtLikeBtn';
 import { timeHelper } from '../../../utils/time-helper';
-import { styled } from 'styled-components';
 
-//자신 댓글인지 확인해서 맞으면 삭제 버튼 & 색상 다르게 보여주기
-//현재 시간을 0시간전으로 계산해서 보여주기
 const OneComment = ({
     isMobile,
     data,

--- a/src/components/rankingpage/rightSection/RankUserInfo.jsx
+++ b/src/components/rankingpage/rightSection/RankUserInfo.jsx
@@ -2,12 +2,9 @@ import { S } from '../Ranking.style';
 import { useSearchParams } from 'react-router-dom';
 
 //오른쪽 섹션에 나오는 웹의 디테일 페이지
-//기본은 1, 쿼리스트링의 id가 바뀔 때마다 해당 id로 api 요청해서 보여주기
-//commentList와 따로 해야한다?
 const RankUserInfo = ({ data, loading }) => {
     const [searchParams, setSearchParams] = useSearchParams();
 
-    // const { owner, score, tableTypeContent } = data;
     const rank = searchParams.get('rank') || 1;
 
     return (


### PR DESCRIPTION
## Summary

### 작업한 페이지명

-  웹 랭킹보드 페이지의 디테일 페이지(오른쪽) 렌더링을 개선하였습니다. 기존 랭킹 데이터를 사용해 랭킹, 이름, 이미지가 바로 나오게 하였습니다.

[기존]

https://github.com/SamwaMoney/Timetable-Artist-front/assets/125418818/719cbe69-5b24-4d68-9f08-b4c493579813

[수정]

https://github.com/SamwaMoney/Timetable-Artist-front/assets/125418818/a6a1e676-417e-4041-8549-f81e72f055b9


## To Reviewers

-   전달하고 싶은 내용 (만약 재사용 가능한 컴포넌트 있다면 설명)
